### PR TITLE
only require webdrivers if missing selenium_hub_url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  # Easy installation and use of web drivers to run system tests with browsers
+  gem 'webdrivers', require: !ENV["SELENIUM_HUB_URL"]
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
https://github.com/flavorjones/chromedriver-helper is deprecated and should switch to webdrivers. This isn't too important since the driver is installed and reachable through selenium hub.